### PR TITLE
Change offset(nan) and sync(0) to WARNING

### DIFF
--- a/src/alert.py
+++ b/src/alert.py
@@ -211,7 +211,7 @@ class NTPAlerter(object):
         return None
 
     def custom_message_sync(self, result):
-        if result == 'CRITICAL':
+        if result == 'WARNING':
             return '%s: No sync peer selected' % (result,)
         elif result == 'OK':
             return '%s: Time is in sync with %s' % (result, self.objs['peers'].syncpeer())

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -177,9 +177,21 @@ class MetricClassifier(object):
         Classify the value of a single metric according to the existing definitions.
         """
         if metric in self.metricdefs:
-            return _classify(value, self.metricdefs[metric])
+            result = self.check_special_cases(metric, value)
+            return (result if result else _classify(
+                    value, self.metricdefs[metric]))
         else:
             raise ValueError('Missing definition for metric %s' % metric)
+
+    def check_special_cases(self, metric, value):
+        """
+        Handle special cases of specific combinations of metrics and their values.
+        """
+        if metric == "offset" and str(value) == "nan":
+            return "WARNING"
+        if metric == "sync" and value == 0:
+            return "WARNING"
+        return None
 
     def classify_metrics(self, metrics):
         """
@@ -200,7 +212,7 @@ class MetricClassifier(object):
         metric = None
         worst = -1
         try:
-            for m in metrics:
+            for m in reversed(metrics):
                 if m in self.results:
                     rc = return_code_for_classification(self.results[m])
                     if rc > worst:

--- a/unit_tests/test_classifier.py
+++ b/unit_tests/test_classifier.py
@@ -133,6 +133,8 @@ badmetricdefs = {
     'd': ('high', 0, 10),
 }
 
+samplechecks = ['a', 'b', 'c', 'd']
+
 samplemetrics = {
     'a': -10,
     'b': 10,
@@ -266,9 +268,9 @@ class TestNTPPeers(unittest.TestCase):
     def test_classify_process(self):
         mc = MetricClassifier(goodmetricdefs)
         self.assertEqual(mc.classify_metrics(samplemetrics), samplemetricresults)
-        self.assertEqual(mc.worst_metric(samplemetrics), ('d', 3))
-        self.assertEqual(mc.return_code(samplemetrics), 3)
-        self.assertEqual(mc.return_code(samplemetrics, unknown_as_critical=True), 2)
+        self.assertEqual(mc.worst_metric(samplechecks), ('d', 3))
+        self.assertEqual(mc.return_code(samplechecks), 3)
+        self.assertEqual(mc.return_code(samplechecks, unknown_as_critical=True), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Due to network instability in some environments,
the NTP algorithm may discard all servers/peers
temporarily, triggering CRITICAL Nagios alert
"CRITICAL: offset is out of range (nan)".

There are two problems with that alert:
1) The message is misleading, as offset=nan does
not mean anything. The worst metric selection
hides the real alert "CRITICAL: No sync peer selected".
Therefore, the worst metric selection list is reversed,
as when "No sync peer selected" happens,
"offset is out of range (nan)" always happens as well.

2) The problem is usually transient and does not
require immediate attention. It may go away with
network workload changes, or may persist until the
root cause of the issue is investigated. Given that it
is of "CRITICAL" level, it obfuscates other much more
critical alerts from NTPmon and also Nagios. Therefore,
the WARNING level is more appropriate.

Closes #5 