### PR TITLE
Correctly detect when no NTP server is running

### DIFF
--- a/src/alert.py
+++ b/src/alert.py
@@ -170,6 +170,8 @@ class NTPAlerter(object):
         Get metrics from each registered metric source and add all relevant aliases.
         """
         self.metrics = {}
+        if checkobjs is None:
+            return
         self.objs = checkobjs
         for o in self.objs:
             self.metrics.update(self.objs[o].getmetrics())

--- a/src/process.py
+++ b/src/process.py
@@ -68,7 +68,8 @@ def execute_subprocess(cmd, timeout, debug, errfatal):
 def detect_implementation():
     """Attempt to detect implementation based on the name of the running NTP server process."""
     implementation = NTPProcess()
-    implementation.getprocess()
+    if implementation.getprocess() is None:
+        return None
     if implementation.name:
         return implementation.name
     else:
@@ -132,8 +133,12 @@ def ntpchecks(checks, debug, implementation=None):
 
     if implementation not in _progs:
         implementation = detect_implementation()
-        if implementation is None:
-            return None
+
+    if 'proc' in checks:
+        objs['proc'] = NTPProcess()
+
+    if implementation is None:
+        return objs
 
     for check in checks:
         if ((check in ['offset', 'peers', 'reach', 'sync'])
@@ -141,9 +146,6 @@ def ntpchecks(checks, debug, implementation=None):
             (output, elapsed) = execute('peers', debug=debug, implementation=implementation)
             objs['peers'] = NTPPeers(output, elapsed)
             break
-
-    if 'proc' in checks:
-        objs['proc'] = NTPProcess()
 
     if 'trace' in checks:
         (output, elapsed) = execute('trace', debug=debug, implementation=implementation)


### PR DESCRIPTION
This stops check_ntpmon from producing python tracebacks when no NTP server is running.