### PR TITLE
Do not allow NaN to be produced as a metric

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -17,12 +17,14 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import math
+
 
 def _add_alias(metrics, name, alias):
     """
     Add an alias for a single named metric
     """
-    if name in metrics:
+    if name in metrics and not math.isnan(metrics[name]):
         metrics[alias] = metrics[name]
         return True
     else:


### PR DESCRIPTION
@rodrigogansobarbieri This is my alternative to PR #7.  I don't think any metrics should be producing NaN at all - it's better to leave them out than to report NaN to Nagios or Telegraf.  Let me know what you think.  I think this should at least prevent the "CRITICAL: offset is out of range (nan)" nonsense, but I need to develop some test cases and see if it makes sense every time.