### PR TITLE
Use 'sync-offset-mean' for offset metric

### DIFF
--- a/src/alert.py
+++ b/src/alert.py
@@ -36,7 +36,7 @@ Aliases for all metrics
 """
 _aliases = {
     # peer metrics
-    'offset': ('survivor-offset-mean', 'outlier-offset-mean', 'backup-offset-mean', 'all-offset-mean'),
+    'offset': ('sync-offset-mean', 'survivor-offset-mean', 'outlier-offset-mean', 'backup-offset-mean', 'all-offset-mean'),
     'peers': 'all',
     'reach': 'all-reach-mean',
     'sync': None,


### PR DESCRIPTION
ntpmon uses 'survivor-offset-mean' for offset metric by default.
Survivors include survivor ('^+'), sync ('^*') and pps ('^o')
sources in 'chronyc sources' output.

'+' indicates acceptable sources which are combined with the selected
source but not currently synchronised. '^o' sources are no longer
preseted in chronyc version 3.2. The sync('*') source is the peer
that the local clock will be synchronised with. In my opinion,
'sync-offset-mean' is a better metric for offset than 'survivor-offset-mean'

Our monitoring system often triggers false postive alerts about ntp
offset out of range. This pull request proposes to use 'sync-offset-mean'
for offset metric.  Highly appreciated if you can merge this pull
request.