### PR TITLE
Don't send metrics with no value in nagios perfdata

### DIFF
--- a/src/alert.py
+++ b/src/alert.py
@@ -398,8 +398,6 @@ class NTPAlerter(object):
                     fmt = _formats[m][1] if _formats[m][1] != '%' else 'f'
                 val = self.mc.fmtstr(fmt) % self.metrics[m]
                 items.append('%s=%s' % (m, val))
-            else:
-                items.append('%s=' % (m,))
         return ' '.join(items)
 
     def return_code(self):


### PR DESCRIPTION
At least icinga2's GraphiteWriter fails to parse perfdata without values and spams the log with error messages like:

`Ignoring invalid perfdata for checkable 'host1!ntpmon' and command 'ntpmon' with value: tracehosts=`

Anyways, I'm not sure how other consumers of this data behave.